### PR TITLE
Validate process timeout on runtime

### DIFF
--- a/src/Commands/Run/StageExecutor.php
+++ b/src/Commands/Run/StageExecutor.php
@@ -113,6 +113,9 @@ class StageExecutor
             while (count($processes)) {
                 foreach ($processes as $id => $runningCommand) {
                     if ($runningCommand->isRunning()) {
+
+                        $runningCommand->getProcess()->checkTimeout();
+                        
                         continue;
                     }
                     unset($processes[$id]);


### PR DESCRIPTION
What is a big surprise for me, symfony process requires calling checkTimeout method in order to verify is it reached. This fixes an issue.