### PR TITLE
Add new option to override the config path to RunCommand

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -83,7 +83,12 @@ class RunCommand extends Command
         $this
             ->setName('run')
             ->setDescription('Run tests')
-            ->addOption(self::CONFIG, self::CONFIG_SHORT, InputOption::VALUE_REQUIRED, 'Configuration file to read')
+            ->addOption(
+                self::CONFIG,
+                self::CONFIG_SHORT,
+                InputOption::VALUE_REQUIRED,
+                'Configuration file to read',
+                ConfigReader::CONFIG_FILE)
             ->addArgument(self::VOLUME, InputArgument::OPTIONAL, 'Docker volume containing data')
             ->addArgument(self::GIT_COMMIT, InputArgument::OPTIONAL, 'Commit id');
         $this->workingDir = getcwd();

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -21,6 +21,7 @@ namespace Trivago\Rumi\Commands;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -35,6 +36,8 @@ use Trivago\Rumi\Timer;
 
 class RunCommand extends Command
 {
+    const CONFIG = 'config';
+    const CONFIG_SHORT = 'c';
     const GIT_COMMIT = 'git_commit';
     const VOLUME = 'volume';
 
@@ -80,6 +83,7 @@ class RunCommand extends Command
         $this
             ->setName('run')
             ->setDescription('Run tests')
+            ->addOption(self::CONFIG, self::CONFIG_SHORT, InputOption::VALUE_REQUIRED, 'Configuration file to read')
             ->addArgument(self::VOLUME, InputArgument::OPTIONAL, 'Docker volume containing data')
             ->addArgument(self::GIT_COMMIT, InputArgument::OPTIONAL, 'Commit id');
         $this->workingDir = getcwd();
@@ -114,7 +118,7 @@ class RunCommand extends Command
                 $this->volume = $this->getWorkingDir();
             }
             $timeTaken = Timer::execute(function () use ($input, $output) {
-                $runConfig = $this->configReader->getConfig($this->getWorkingDir());
+                $runConfig = $this->configReader->getConfig($this->getWorkingDir(), $input->getOption(self::CONFIG));
 
                 /** @var JobConfigBuilder $jobConfigBuilder */
                 $jobConfigBuilder = $this->container->get('trivago.rumi.job_config_builder');

--- a/src/Services/ConfigReader.php
+++ b/src/Services/ConfigReader.php
@@ -28,18 +28,20 @@ class ConfigReader
 
     /**
      * @param $workingDir
+     * @param $configFile
      *
      * @throws \Exception
      *
      * @return RunConfig
      */
-    public function getConfig($workingDir)
+    public function getConfig($workingDir, $configFile = null)
     {
-        $configFilePath = $workingDir . self::CONFIG_FILE;
+        $configFileName = $configFile ?: self::CONFIG_FILE;
+        $configFilePath = $workingDir . $configFileName;
 
         if (!file_exists($configFilePath)) {
             throw new \Exception(
-                'Required file \'' . self::CONFIG_FILE . '\' does not exist',
+                'Required file \'' . $configFileName . '\' does not exist',
                 ReturnCodes::RUMI_YML_DOES_NOT_EXIST
             );
         }

--- a/src/Services/ConfigReader.php
+++ b/src/Services/ConfigReader.php
@@ -34,14 +34,13 @@ class ConfigReader
      *
      * @return RunConfig
      */
-    public function getConfig($workingDir, $configFile = null)
+    public function getConfig($workingDir, $configFile = self::CONFIG_FILE)
     {
-        $configFileName = $configFile ?: self::CONFIG_FILE;
-        $configFilePath = $workingDir . $configFileName;
+        $configFilePath = $workingDir . $configFile;
 
         if (!file_exists($configFilePath)) {
             throw new \Exception(
-                'Required file \'' . $configFileName . '\' does not exist',
+                'Required file \'' . $configFile . '\' does not exist',
                 ReturnCodes::RUMI_YML_DOES_NOT_EXIST
             );
         }

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -312,6 +312,27 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalledTimes(1);
     }
 
+    public function testGivenDifferentCiYamlFileName_WhenExecuted_ThenLookForThatFileInstead()
+    {
+        // given
+        $configFile = '../rumi-dev.yml';
+        $exceptionMessage = 'Required file \'' . $configFile . '\' does not exist';
+        $input = new ArrayInput([ '--config' => $configFile ]);
+
+        $this->configReader
+            ->getConfig(Argument::any(), Argument::is($configFile))
+            ->willThrow(new \Exception($exceptionMessage, ReturnCodes::RUMI_YML_DOES_NOT_EXIST))
+            ->shouldBeCalledTimes(1);
+
+        // when
+        $returnCode = $this->command->run($input, $this->output);
+
+        // then
+        $this->assertNotEquals(ConfigReader::CONFIG_FILE, $configFile);
+        $this->assertSame("Required file '" . $configFile . "' does not exist", trim($this->output->fetch()));
+        $this->assertEquals(ReturnCodes::RUMI_YML_DOES_NOT_EXIST, $returnCode);
+    }
+
     /**
      * @param $isSuccessful
      *

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -94,7 +94,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testGivenNoCiYamlFile_WhenExecuted_ThenDisplaysErrorMessage()
     {
         // given
-        $this->configReader->getConfig(Argument::any())->willThrow(new \Exception(
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))->willThrow(new \Exception(
             'Required file \'' . ConfigReader::CONFIG_FILE . '\' does not exist',
             ReturnCodes::RUMI_YML_DOES_NOT_EXIST
         ));
@@ -110,7 +110,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testGivenCiYamlSyntaxIsWrong_WhenExecuted_ThenDisplaysErrorMessage()
     {
         // given
-        $this->configReader->getConfig(Argument::any())->willThrow(new ParseException(
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))->willThrow(new ParseException(
             'Unable to parse at line 2 (near "::yaml_file").'
         ));
 
@@ -132,7 +132,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $processFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any())
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );
@@ -164,7 +164,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $processFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any())
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );
@@ -194,7 +194,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $oProcessFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any())
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))
             ->willReturn(
                 new RunConfig([
                     'Stage one' => [
@@ -264,7 +264,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $oProcessFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any())
+        $this->configReader->getConfig(Argument::any(), Argument::is(null))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -94,7 +94,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testGivenNoCiYamlFile_WhenExecuted_ThenDisplaysErrorMessage()
     {
         // given
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))->willThrow(new \Exception(
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))->willThrow(new \Exception(
             'Required file \'' . ConfigReader::CONFIG_FILE . '\' does not exist',
             ReturnCodes::RUMI_YML_DOES_NOT_EXIST
         ));
@@ -110,7 +110,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
     public function testGivenCiYamlSyntaxIsWrong_WhenExecuted_ThenDisplaysErrorMessage()
     {
         // given
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))->willThrow(new ParseException(
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))->willThrow(new ParseException(
             'Unable to parse at line 2 (near "::yaml_file").'
         ));
 
@@ -132,7 +132,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $processFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );
@@ -164,7 +164,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $processFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );
@@ -194,7 +194,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $oProcessFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))
             ->willReturn(
                 new RunConfig([
                     'Stage one' => [
@@ -264,7 +264,7 @@ class RunCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->container->set('trivago.rumi.process.running_processes_factory', $oProcessFactory->reveal());
 
-        $this->configReader->getConfig(Argument::any(), Argument::is(null))
+        $this->configReader->getConfig(Argument::any(), Argument::is(ConfigReader::CONFIG_FILE))
             ->willReturn(
                 new RunConfig(['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]], [], null)
             );


### PR DESCRIPTION
This adds the option `--config` (with shortcut `-c`) to `RunCommand`, so the config path that *rumi* uses can be overloaded.