### PR TITLE
Add PHP Mess Detector rule sets for rumi

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="My first PHPMD rule set"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>
+        Custom rule set for PROJECT_NAME
+
+        For futher information about the rule set please visit
+        https://phpmd.org/rules/index.html.
+    </description>
+
+    <rule ref="rulesets/unusedcode.xml" />
+    <rule ref="rulesets/codesize.xml" />
+    <rule ref="rulesets/cleancode.xml" />
+    <rule ref="rulesets/controversial.xml/Superglobals" />
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable" />
+        <exclude name="LongVariable" />
+    </rule>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -7,9 +7,9 @@
          xsi:noNamespaceSchemaLocation="
                      http://pmd.sf.net/ruleset_xml_schema.xsd">
     <description>
-        Custom rule set for PROJECT_NAME
+        PHP Mess Detector rule sets for rumi
 
-        For futher information about the rule set please visit
+        For further information about the rule set please visit
         https://phpmd.org/rules/index.html.
     </description>
 


### PR DESCRIPTION
PHPMD takes a given PHP source code base and look for several potential problems within that source. These problems can be things like:

Possible bugs
Suboptimal code
Overcomplicated expressions
Unused parameters, methods, properties

PHPStorm supports PHPMD. It just need to be enabled under Inspection -> PHP Mess Detector validation.   