### PR TITLE
Implementation of disabling the tear down process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = 2

--- a/src/Commands/Run/StageExecutor.php
+++ b/src/Commands/Run/StageExecutor.php
@@ -51,8 +51,6 @@ class StageExecutor
      */
     private $runningProcessesFactory;
 
-
-
     /**
      * @param EventDispatcherInterface $eventDispatcher
      * @param DockerComposeYamlBuilder $dockerComposeYamlBuilder

--- a/src/Commands/Run/StageExecutor.php
+++ b/src/Commands/Run/StageExecutor.php
@@ -51,6 +51,8 @@ class StageExecutor
      */
     private $runningProcessesFactory;
 
+
+
     /**
      * @param EventDispatcherInterface $eventDispatcher
      * @param DockerComposeYamlBuilder $dockerComposeYamlBuilder

--- a/src/Commands/Run/StageExecutor.php
+++ b/src/Commands/Run/StageExecutor.php
@@ -32,7 +32,7 @@ use Trivago\Rumi\Models\RunningCommand;
 use Trivago\Rumi\Models\RunningCommandCollection;
 use Trivago\Rumi\Models\StageConfig;
 use Trivago\Rumi\Models\VCSInfo\VCSInfoInterface;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\RunningProcessFactoryInterface;
 
 class StageExecutor
 {
@@ -47,19 +47,19 @@ class StageExecutor
     private $dockerComposeYamlBuilder;
 
     /**
-     * @var RunningProcessesFactory
+     * @var RunningProcessFactoryInterface
      */
     private $runningProcessesFactory;
 
     /**
      * @param EventDispatcherInterface $eventDispatcher
      * @param DockerComposeYamlBuilder $dockerComposeYamlBuilder
-     * @param RunningProcessesFactory  $runningProcessesFactory
+     * @param RunningProcessFactoryInterface  $runningProcessesFactory
      */
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         DockerComposeYamlBuilder $dockerComposeYamlBuilder,
-        RunningProcessesFactory $runningProcessesFactory
+        RunningProcessFactoryInterface $runningProcessesFactory
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->dockerComposeYamlBuilder = $dockerComposeYamlBuilder;

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -29,11 +29,10 @@ use Trivago\Rumi\Events\RunFinishedEvent;
 use Trivago\Rumi\Events\RunStartedEvent;
 use Trivago\Rumi\Events\StageFinishedEvent;
 use Trivago\Rumi\Events\StageStartedEvent;
-use Trivago\Rumi\Exceptions\SkipException;
 use Trivago\Rumi\Models\RunConfig;
 use Trivago\Rumi\Models\VCSInfo\GitInfo;
 use Trivago\Rumi\Models\VCSInfo\VCSInfoInterface;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\AbstractRunningProcessFactory;
 use Trivago\Rumi\Services\ConfigReader;
 use Trivago\Rumi\Timer;
 
@@ -142,9 +141,9 @@ class RunCommand extends CommandAbstract
             }
 
             if ($input->getOption(self::OPTION_NO_TEAR_DOWN)) {
-                RunningProcessesFactory::disableTearDown();
+                AbstractRunningProcessFactory::disableTearDown();
             } else {
-                RunningProcessesFactory::enableTearDown();
+                AbstractRunningProcessFactory::enableTearDown();
             }
 
             $VCSInfo = new GitInfo(

--- a/src/Models/RunningCommand.php
+++ b/src/Models/RunningCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 use Trivago\Rumi\Events;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\RunningProcessFactoryInterface;
 
 class RunningCommand
 {
@@ -37,7 +37,7 @@ class RunningCommand
     private $yamlPath = '';
 
     /**
-     * @var RunningProcessesFactory
+     * @var RunningProcessFactoryInterface
      */
     private $runningProcessesFactory;
 
@@ -58,13 +58,13 @@ class RunningCommand
     /**
      * @param JobConfig $jobConfig
      * @param string $yamlPath
-     * @param RunningProcessesFactory $factory
+     * @param RunningProcessFactoryInterface $factory
      * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(
         JobConfig $jobConfig,
         $yamlPath,
-        RunningProcessesFactory $factory,
+        RunningProcessFactoryInterface $factory,
         EventDispatcherInterface $eventDispatcher
     ) {
         $this->jobConfig = $jobConfig;

--- a/src/Models/RunningCommandCollection.php
+++ b/src/Models/RunningCommandCollection.php
@@ -28,7 +28,8 @@ class RunningCommandCollection implements \IteratorAggregate, \ArrayAccess
     /**
      * @param RunningCommand $command
      */
-    public function add(RunningCommand $command){
+    public function add(RunningCommand $command)
+    {
         $this->commands[] = $command;
     }
 

--- a/src/Process/NoTeardownRunningProcessFactory.php
+++ b/src/Process/NoTeardownRunningProcessFactory.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2016 trivago GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Trivago\Rumi\Process;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * @package Trivago\Rumi\Process
+ * @author Dejan Spasic <spasic.dejan@yahoo.de>
+ */
+class NoTeardownRunningProcessFactory extends AbstractRunningProcessFactory
+{
+    /**
+     * @param string $yamlPath
+     * @param string $tmpName
+     *
+     * @return Process
+     */
+    public function getTearDownProcess(string $yamlPath, string $tmpName): Process
+    {
+        return new class('echo "skip tear down" > /dev/null') extends Process {
+            //@codingStandardsIgnoreStart
+            public function run($callback = null) {}
+            public function start(callable $callback = null) {}
+            //@codingStandardsIgnoreEnd
+        };
+    }
+
+}

--- a/src/Process/RunningProcessFactory.php
+++ b/src/Process/RunningProcessFactory.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2016 trivago GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Trivago\Rumi\Process;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * @package Trivago\Rumi\Process
+ * @author Dejan Spasic <spasic.dejan@yahoo.de>
+ */
+class RunningProcessFactory extends AbstractRunningProcessFactory
+{
+    /**
+     * @param string $yamlPath
+     * @param string $tmpName
+     *
+     * @return Process
+     */
+    public function getTearDownProcess(string $yamlPath, string $tmpName): Process
+    {
+        $process = new Process(
+            'docker rm -f ' . $tmpName . ';
+            docker-compose -f ' . $yamlPath . ' rm -v --force;
+            docker rm -f $(docker-compose -f ' . $yamlPath . ' ps -q)'
+        );
+        $process->setTimeout(300)->setIdleTimeout(300);
+
+        return $process;
+    }
+}

--- a/src/Process/RunningProcessFactoryInterface.php
+++ b/src/Process/RunningProcessFactoryInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2016 trivago GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Trivago\Rumi\Process;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * @package Trivago\Rumi\Process
+ * @author Dejan Spasic <spasic.dejan@yahoo.de>
+ */
+interface RunningProcessFactoryInterface
+{
+    /**
+     * @param string $yamlPath
+     * @param string $tmpName
+     * @param string $ciImage
+     * @param int $timeout
+     * @return Process
+     */
+    public function getJobStartProcess(string $yamlPath, string $tmpName, string $ciImage, int $timeout): Process;
+
+    /**
+     * @param string $yamlPath
+     * @param string $tmpName
+     * @return Process
+     */
+    public function getTearDownProcess(string $yamlPath, string $tmpName): Process;
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,7 +13,7 @@
         <service class="Trivago\Rumi\Commands\Run\StageExecutor" id="trivago.rumi.commands.run.stage_executor">
             <argument id="trivago.rumi.event_dispatcher" type="service"/>
             <argument id="trivago.rumi.docker_compose_yaml_builder" type="service"/>
-            <argument id="trivago.rumi.process.running_processes_factory" type="service"/>
+            <argument id="trivago.rumi.process.running_process_factory" type="service"/>
         </service>
 
         <service class="Trivago\Rumi\Builders\ComposeParser" id="trivago.rumi.builders.compose_handler"/>
@@ -34,7 +34,11 @@
             <argument id="trivago.rumi.process.cache_process_factory" type="service"/>
         </service>
 
-        <service class="Trivago\Rumi\Process\RunningProcessesFactory" id="trivago.rumi.process.running_processes_factory"/>
+        <service class="Trivago\Rumi\Process\RunningProcessFactoryInterface"
+                 id="trivago.rumi.process.running_process_factory"
+                 shared="false">
+            <factory class="Trivago\Rumi\Process\AbstractRunningProcessFactory" method="createFactory"/>
+        </service>
         <service class="Trivago\Rumi\Process\GitCheckoutProcessFactory" id="trivago.rumi.process.git_checkout_process_factory"/>
         <service class="Trivago\Rumi\Process\CacheProcessFactory" id="trivago.rumi.process.cache_process_factory"/>
         <service class="Trivago\Rumi\Process\VolumeInspectProcessFactory" id="trivago.rumi.process.volume_inspect_process_factory"/>

--- a/src/RumiApplication.php
+++ b/src/RumiApplication.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Trivago\Rumi\Commands\CacheRestoreCommand;
 use Trivago\Rumi\Commands\CacheStoreCommand;
 use Trivago\Rumi\Commands\CheckoutCommand;
@@ -46,6 +47,11 @@ class RumiApplication extends Application
 
         $this->initContainer();
         $this->setUpCommands();
+    }
+
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->container->get('trivago.rumi.event_dispatcher');
     }
 
     private function initContainer()

--- a/src/Services/ConfigReader.php
+++ b/src/Services/ConfigReader.php
@@ -52,7 +52,7 @@ class ConfigReader
      */
     public function getRunConfig($workingDir, $configFile)
     {
-        $configFilePath = $workingDir . $configFile;
+        $configFilePath = $workingDir . ltrim($configFile, '/');
 
         if (!file_exists($configFilePath)) {
             throw new \Exception(

--- a/tests/Commands/Fixtures/rumiConfigBuildFails.yml
+++ b/tests/Commands/Fixtures/rumiConfigBuildFails.yml
@@ -1,0 +1,8 @@
+stages:
+  Stage one:
+    Job one:
+      docker:
+        okay:
+          image: hello-world
+      commands:
+        - unknownCommand

--- a/tests/Commands/Fixtures/rumiConfigBuildIsOkay.yml
+++ b/tests/Commands/Fixtures/rumiConfigBuildIsOkay.yml
@@ -1,0 +1,8 @@
+stages:
+  Stage one:
+    Job one:
+      docker:
+        okay:
+          image: hello-world
+      commands:
+        - cd .

--- a/tests/Commands/Fixtures/rumiConfigBuildTimeout.yml
+++ b/tests/Commands/Fixtures/rumiConfigBuildTimeout.yml
@@ -1,0 +1,8 @@
+stages:
+  Stage one:
+    Job one:
+      docker:
+        okay:
+          image: hello-world
+      commands:
+        - while true:; do sleep 1; done

--- a/tests/Commands/Fixtures/rumiConfigWithSyntaxError.yml
+++ b/tests/Commands/Fixtures/rumiConfigWithSyntaxError.yml
@@ -1,0 +1,2 @@
+-;:23@@@@
+asdlfkjasdf

--- a/tests/Commands/Run/StageExecutorTest.php
+++ b/tests/Commands/Run/StageExecutorTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Trivago\Rumi\Builders\DockerComposeYamlBuilder;
 use Trivago\Rumi\Models\VCSInfo\VCSInfoInterface;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\RunningProcessFactoryInterface;
 
 class StageExecutorTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,7 +27,7 @@ class StageExecutorTest extends \PHPUnit_Framework_TestCase
     private $dockerComposeYamlBuilder;
 
     /**
-     * @var RunningProcessesFactory|ObjectProphecy
+     * @var RunningProcessFactoryInterface|ObjectProphecy
      */
     private $runningProcessFactory;
 
@@ -51,7 +51,7 @@ class StageExecutorTest extends \PHPUnit_Framework_TestCase
     {
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $this->dockerComposeYamlBuilder = $this->prophesize(DockerComposeYamlBuilder::class);
-        $this->runningProcessFactory = $this->prophesize(RunningProcessesFactory::class);
+        $this->runningProcessFactory = $this->prophesize(RunningProcessFactoryInterface::class);
         $this->VCSInfo = $this->prophesize(VCSInfoInterface::class);
 
         $this->outputInterface = new BufferedOutput();

--- a/tests/Commands/Run/StageExecutorTest.php
+++ b/tests/Commands/Run/StageExecutorTest.php
@@ -6,7 +6,6 @@
 
 namespace Trivago\Rumi\Commands\Run;
 
-
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -21,14 +21,10 @@ namespace Trivago\Rumi\Commands;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Trivago\Rumi\Events;
 use Trivago\Rumi\Events\RunFinishedEvent;
 use Trivago\Rumi\Events\RunStartedEvent;
-use Trivago\Rumi\Process\RunningProcessFactory;
 use Trivago\Rumi\RumiApplication;
-use Trivago\Rumi\Services\ConfigReader;
 
 /**
  * @covers \Trivago\Rumi\Commands\RunCommand

--- a/tests/Commands/RunCommandTest.php
+++ b/tests/Commands/RunCommandTest.php
@@ -18,431 +18,190 @@
 
 namespace Trivago\Rumi\Commands;
 
-use org\bovigo\vfs\vfsStream;
 use Prophecy\Argument;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Process\Exception\ProcessTimedOutException;
-use Symfony\Component\Process\Process;
-use Symfony\Component\Yaml\Exception\ParseException;
 use Trivago\Rumi\Events;
-use Trivago\Rumi\Events\JobFinishedEvent;
-use Trivago\Rumi\Events\JobStartedEvent;
 use Trivago\Rumi\Events\RunFinishedEvent;
 use Trivago\Rumi\Events\RunStartedEvent;
-use Trivago\Rumi\Events\StageFinishedEvent;
-use Trivago\Rumi\Events\StageStartedEvent;
-use Trivago\Rumi\Models\CacheConfig;
-use Trivago\Rumi\Models\RunConfig;
-use Trivago\Rumi\Models\StagesCollection;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\RunningProcessFactory;
+use Trivago\Rumi\RumiApplication;
 use Trivago\Rumi\Services\ConfigReader;
 
 /**
  * @covers \Trivago\Rumi\Commands\RunCommand
  * @covers \Trivago\Rumi\Commands\Run\StageExecutor
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 class RunCommandTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var BufferedOutput
+     * @var RumiApplication
      */
-    private $output;
+    private $app;
 
-    /**
-     * @var RunCommand
-     */
-    private $command;
-
-    /**
-     * @var ContainerBuilder
-     */
-    private $container;
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
-
-    /**
-     * @var ConfigReader
-     */
-    private $configReader;
-
-    /**
-     * @var RunningProcessesFactory
-     */
-    private $processFactory;
-
-    public function setUp()
+    protected function setUp()
     {
-        $this->output = new BufferedOutput();
-
-        vfsStream::setup('directory');
-
-        $this->container = new ContainerBuilder();
-        $loader = new XmlFileLoader($this->container, new FileLocator(__DIR__));
-        $loader->load('../../src/Resources/config/services.xml');
-
-        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
-        $this->container->set('trivago.rumi.event_dispatcher', $this->eventDispatcher->reveal());
-
-        /* @var RunningProcessesFactory $processFactory */
-        $this->processFactory = $this->prophesize(RunningProcessesFactory::class);
-        $this->container->set('trivago.rumi.process.running_processes_factory', $this->processFactory->reveal());
-
-        $this->configReader = $this->prophesize(ConfigReader::class);
-        $this->command = new RunCommand(
-            $this->eventDispatcher->reveal(),
-            $this->configReader->reveal(),
-            $this->container->get('trivago.rumi.commands.run.stage_executor'),
-            $this->container->get('trivago.rumi.job_config_builder')
-        );
-        $this->command->setWorkingDir(vfsStream::url('directory'));
+        $this->app = new RumiApplication();
+        $this->app->setAutoExit(false);
     }
 
     public function testGivenNoCiYamlFile_WhenExecuted_ThenDisplaysErrorMessage()
     {
-        // given
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))->willThrow(new \Exception(
-            'Required file \''.CommandAbstract::DEFAULT_CONFIG.'\' does not exist',
-            ReturnCodes::RUMI_YML_DOES_NOT_EXIST
-        ));
+        $output = new BufferedOutput();
+        $rumiFile = 'IHaveNoConfig4U';
 
-        // when
-        $returnCode = $this->command->run(new ArrayInput([]), $this->output);
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
+        );
 
-        // then
-        $this->assertSame("Required file '".CommandAbstract::DEFAULT_CONFIG."' does not exist", trim($this->output->fetch()));
-        $this->assertEquals(ReturnCodes::RUMI_YML_DOES_NOT_EXIST, $returnCode);
+        $this->assertContains(
+            sprintf("Required file '%s' does not exist", $rumiFile),
+            $output->fetch()
+        );
+        $this->assertExitCode(ReturnCodes::RUMI_YML_DOES_NOT_EXIST, $exitCode);
     }
 
     public function testGivenCiYamlSyntaxIsWrong_WhenExecuted_ThenDisplaysErrorMessage()
     {
-        // given
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))->willThrow(new ParseException(
-            'Unable to parse at line 2 (near "::yaml_file").'
-        ));
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigWithSyntaxError.yml';
 
-        // when
-        $returnCode = $this->command->run(new ArrayInput(['volume' => '.']), $this->output);
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
+        );
 
-        // then
-        $this->assertSame('Unable to parse at line 2 (near "::yaml_file").', trim($this->output->fetch()));
-        $this->assertEquals(ReturnCodes::FAILED, $returnCode);
+        $this->assertContains('Unable to parse at line 1 (near "-;:23@@@@")', $output->fetch());
+        $this->assertExitCode(ReturnCodes::FAILED, $exitCode);
+    }
+
+    public function testGivenCiYamlAbsolutePath_WhenExecuted_ThenConfigFileShouldBeFound()
+    {
+        $output = new BufferedOutput();
+        $rumiFile = __DIR__ . '/Fixtures/rumiConfigWithSyntaxError.yml';
+
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
+        );
+
+        $this->assertContains('Unable to parse at line 1 (near "-;:23@@@@")', $output->fetch());
+        $this->assertExitCode(ReturnCodes::FAILED, $exitCode);
     }
 
     public function testGivenValidCiYamlAndBuildIsOk_WhenExecuted_ThenDisplaysConfirmationMessage()
     {
-        // given
-        $this->setProcessFactoryMock(
-            $this->getStartProcess(true),
-            $this->getTearDownProcess()
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigBuildIsOkay.yml';
+
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
         );
 
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))
-            ->willReturn(
-                new RunConfig(
-                    new StagesCollection(
-                        $this->container->get('trivago.rumi.job_config_builder'),
-                        ['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]]
-                    ),
-                    new CacheConfig([]),
-                    "")
-            );
+        $bufferedOutput = $output->fetch();
 
-        // when
-        $returnCode = $this->command->run(new ArrayInput(['volume' => '.']), $this->output);
-
-        // then
-        $commandOutput = $this->output->fetch();
-
-        $this->assertStringStartsWith('Stage: "Stage one"', trim($commandOutput));
-        $this->assertContains('Build successful', $commandOutput);
-        $this->assertEquals(0, $returnCode);
+        $this->assertContains('Build successful', $bufferedOutput);
+        $this->assertContains('Stage: "Stage one"', $bufferedOutput);
+        $this->assertExitCode(ReturnCodes::SUCCESS, $exitCode);
     }
 
     public function testGivenValidCiYamlAndBuildFails_WhenExecuted_ThenDisplaysConfirmationMessage()
     {
-        // given
-        $startProcess = $this->getStartProcess(false);
-        $startProcess->isRunning()->willReturn(true, false);
-        $startProcess->checkTimeout()->willReturn(null);
-        $errorOutput = '##error output##';
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigBuildFails.yml';
 
-        $startProcess->getOutput()->willReturn($errorOutput)->shouldBeCalled();
-        $tearDownProcess = $this->getTearDownProcess();
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
+        );
 
-        $this->setProcessFactoryMock($startProcess, $tearDownProcess);
+        $bufferedOutput = $output->fetch();
 
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))
-            ->willReturn(
-                new RunConfig(
-                    new StagesCollection(
-                        $this->container->get('trivago.rumi.job_config_builder'),
-                        ['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]]
-                    ),
-                    new CacheConfig([]),
-                    "")
-            );
-
-        // when
-        $returnCode = $this->command->run(new ArrayInput(['volume' => '.']), $this->output);
-
-        // then
-        $commandOutput = $this->output->fetch();
-
-        $this->assertStringStartsWith('Stage: "Stage one"', trim($commandOutput));
-        $this->assertContains($errorOutput, $commandOutput);
-        $this->assertNotContains($errorOutput.$errorOutput, $commandOutput);
-        $this->assertEquals(ReturnCodes::FAILED, $returnCode);
+        $this->assertContains('Stage failed', $bufferedOutput);
+        $this->assertContains('Stage: "Stage one"', $bufferedOutput);
+        $this->assertContains('unknownCommand', $bufferedOutput);
+        $this->assertExitCode(ReturnCodes::FAILED, $exitCode);
     }
 
     public function testGivenValidCiYamlAndBuildTimeOuts_WhenExecuted_ThenDisplaysTimeoutMessage()
     {
-        // given
-        $startProcess = $this->getStartProcess(false);
-        $startProcess->isRunning()->willReturn(true, false);
-        $output = '##error output##';
-        $startProcess->getOutput()->willReturn($output)->shouldBeCalled();
-        $startProcess->getCommandLine()->willReturn('abc');
-        $startProcess->getTimeout()->willReturn(1);
-        $startProcess->checkTimeout()->will(function () use ($startProcess) {
-            throw new ProcessTimedOutException($startProcess->reveal(), ProcessTimedOutException::TYPE_GENERAL);
-        });
-        $tearDownProcess = $this->getTearDownProcess();
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigBuildFails.yml';
 
-        $this->setProcessFactoryMock($startProcess, $tearDownProcess);
+        $exitCode = $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
+        );
 
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))
-            ->willReturn(
-                new RunConfig(
-                    new StagesCollection(
-                        $this->container->get('trivago.rumi.job_config_builder'),
-                        ['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]]
-                    ),
-                    new CacheConfig([]),
-                    "")
-            );
+        $bufferedOutput = $output->fetch();
 
-        // when
-        $returnCode = $this->command->run(new ArrayInput(['volume' => '.']), $this->output);
-
-        // then
-        $commandOutput = $this->output->fetch();
-
-        $this->assertStringStartsWith('Stage: "Stage one"', trim($commandOutput));
-        $this->assertContains($output, $commandOutput);
-        $this->assertContains('Process timed out after 1s', $commandOutput);
-        $this->assertNotContains($output.$output, $commandOutput);
-        $this->assertEquals(ReturnCodes::FAILED, $returnCode);
+        $this->assertContains('Stage failed', $bufferedOutput);
+        $this->assertContains('Stage: "Stage one"', $bufferedOutput);
+        $this->assertContains('Process timed out after 1s', $bufferedOutput);
+        $this->assertExitCode(ReturnCodes::FAILED, $exitCode);
     }
 
-    /**
-     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
-     */
     public function testGivenJobsAreSuccessful_WhenRunIsStarted_ThenEventsAreTriggeredWithProperStatuses()
     {
-        // given
-        $startProcess = $this->getStartProcess(true);
-        $tearDownProcess = $this->getTearDownProcess();
+        $listener = $this->prophesize(Listener::class);
+        $listener->listenToAll(Argument::type(RunStartedEvent::class))->shouldBeCalled();
+        $listener->listenToAll(Argument::type(RunFinishedEvent::class))->shouldBeCalled()->will(function ($args) {
+            $this->assertEquals(RunFinishedEvent::STATUS_SUCCESS, $args[0]->getStatus());
+        });
 
-        $this->setProcessFactoryMock($startProcess, $tearDownProcess);
+        $this->app->getEventDispatcher()->addListener(Events::RUN_STARTED, $listener);
+        $this->app->getEventDispatcher()->addListener(Events::RUN_FINISHED, $listener);
 
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))
-            ->willReturn(
-                new RunConfig(
-                    new StagesCollection(
-                        $this->container->get('trivago.rumi.job_config_builder'),
-                        [
-                            'Stage one' => [
-                                'Job one' => ['docker' => ['www' => ['image' => 'abc']]],
-                                'Job two' => ['docker' => ['www' => ['image' => 'abc']]],
-                            ],
-                            'Stage two' => [
-                                'Job one' => ['docker' => ['www' => ['image' => 'abc']]],
-                                'Job two' => ['docker' => ['www' => ['image' => 'abc']]],
-                            ],
-                        ]
-                    ),
-                    new CacheConfig([]),
-                    ""
-                )
-            );
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigBuildIsOkay.yml';
 
-        // when
-        $this->command->run(
-            new ArrayInput(['volume' => '.']), $this->output
+        $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
         );
-
-        // then
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::RUN_STARTED, Argument::type(RunStartedEvent::class))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::STAGE_STARTED, Argument::type(StageStartedEvent::class))
-            ->shouldBeCalledTimes(2);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::JOB_STARTED, Argument::type(JobStartedEvent::class))
-            ->shouldBeCalledTimes(4);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::JOB_FINISHED, Argument::that(function (JobFinishedEvent $e) {
-                return $e->getStatus() == JobFinishedEvent::STATUS_SUCCESS;
-            }))
-            ->shouldBeCalledTimes(4);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::STAGE_FINISHED, Argument::that(function (StageFinishedEvent $e) {
-                return $e->getStatus() == StageFinishedEvent::STATUS_SUCCESS;
-            }))
-            ->shouldBeCalledTimes(2);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::RUN_FINISHED, Argument::that(function (RunFinishedEvent $e) {
-                return $e->getStatus() == RunFinishedEvent::STATUS_SUCCESS;
-            }))
-            ->shouldBeCalledTimes(1);
     }
 
-    /**
-     * @throws \Symfony\Component\Console\Exception\ExceptionInterface
-     */
     public function testGivenJobFails_WhenRunIsStarted_ThenEventsAreTriggeredWithProperStatuses()
     {
-        // given
-        $startProcess = $this->getStartProcess(false);
-        $tearDownProcess = $this->getTearDownProcess();
+        $listener = $this->prophesize(Listener::class);
+        $listener->listenToAll(Argument::type(RunStartedEvent::class))->shouldBeCalled();
+        $listener->listenToAll(Argument::type(RunFinishedEvent::class))->shouldBeCalled()->will(function ($args) {
+            $this->assertEquals(RunFinishedEvent::STATUS_FAILED, $args[0]->getStatus());
+        });
 
-        $this->setProcessFactoryMock($startProcess, $tearDownProcess);
+        $this->app->getEventDispatcher()->addListener(Events::RUN_STARTED, $listener);
+        $this->app->getEventDispatcher()->addListener(Events::RUN_FINISHED, $listener);
 
-        $this->configReader->getRunConfig(Argument::any(), Argument::is(CommandAbstract::DEFAULT_CONFIG))
-            ->willReturn(
-                new RunConfig(
-                    new StagesCollection(
-                        $this->container->get('trivago.rumi.job_config_builder'),
-                        ['Stage one' => ['Job one' => ['docker' => ['www' => ['image' => 'abc']]]]]
-                    ),
-                    new CacheConfig([]),
-                    ""
-                )
-            );
+        $output = new BufferedOutput();
+        $rumiFile = 'tests/Commands/Fixtures/rumiConfigBuildIsOkay.yml';
 
-        // when
-        $this->command->run(
-            new ArrayInput(['volume' => '.']), $this->output
+        $this->app->run(
+            new StringInput(sprintf('run --%s=%s', RunCommand::CONFIG, $rumiFile)),
+            $output
         );
-
-        // then
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::RUN_STARTED, Argument::type(RunStartedEvent::class))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::STAGE_STARTED, Argument::type(StageStartedEvent::class))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::JOB_STARTED, Argument::type(JobStartedEvent::class))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::JOB_FINISHED, Argument::that(function (JobFinishedEvent $e) {
-                return $e->getStatus() == JobFinishedEvent::STATUS_FAILED;
-            }))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::STAGE_FINISHED, Argument::that(function (StageFinishedEvent $e) {
-                return $e->getStatus() == StageFinishedEvent::STATUS_FAILED;
-            }))
-            ->shouldBeCalledTimes(1);
-
-        $this
-            ->eventDispatcher
-            ->dispatch(Events::RUN_FINISHED, Argument::that(function (RunFinishedEvent $e) {
-                return $e->getStatus() == RunFinishedEvent::STATUS_FAILED;
-            }))
-            ->shouldBeCalledTimes(1);
-    }
-
-    public function testGivenDifferentCiYamlFileName_WhenExecuted_ThenLookForThatFileInstead()
-    {
-        // given
-        $configFile = '../rumi-dev.yml';
-        $exceptionMessage = 'Required file \''.$configFile.'\' does not exist';
-        $input = new ArrayInput(['--config' => $configFile]);
-
-        $this->configReader
-            ->getRunConfig(Argument::any(), Argument::is($configFile))
-            ->willThrow(new \Exception($exceptionMessage, ReturnCodes::RUMI_YML_DOES_NOT_EXIST))
-            ->shouldBeCalledTimes(1);
-
-        // when
-        $returnCode = $this->command->run($input, $this->output);
-
-        // then
-        $this->assertNotEquals(CommandAbstract::DEFAULT_CONFIG, $configFile);
-        $this->assertSame("Required file '".$configFile."' does not exist", trim($this->output->fetch()));
-        $this->assertEquals(ReturnCodes::RUMI_YML_DOES_NOT_EXIST, $returnCode);
     }
 
     /**
-     * @param $isSuccessful
-     *
-     * @return \Prophecy\Prophecy\ObjectProphecy|Process
+     * @param $expectedExitCode
+     * @param $exitCode
      */
-    protected function getStartProcess($isSuccessful)
+    private function assertExitCode($expectedExitCode, $exitCode)
     {
-        $startProcess = $this->prophesize(Process::class);
-        $startProcess->start()->shouldBeCalled();
-        $startProcess->isRunning()->willReturn(false)->shouldBeCalled();
-        $startProcess->isSuccessful()->willReturn($isSuccessful)->shouldBeCalled();
-        $startProcess->getOutput()->willReturn('')->shouldBeCalled();
-
-        return $startProcess;
+        $this->assertEquals(
+            $expectedExitCode,
+            $exitCode,
+            sprintf('Expected exit code %s do not match. Got %s.', $expectedExitCode, $exitCode)
+        );
     }
+}
 
-    /**
-     * @return \Prophecy\Prophecy\ObjectProphecy
-     */
-    protected function getTearDownProcess()
-    {
-        $tearDownProcess = $this->prophesize(Process::class);
-        $tearDownProcess->run()->shouldBeCalled();
-
-        return $tearDownProcess;
-    }
-
-    /**
-     * @param $startProcess
-     * @param $tearDownProcess
-     *
-     * @return RunningProcessesFactory
-     */
-    protected function setProcessFactoryMock($startProcess, $tearDownProcess)
-    {
-        $this->processFactory->getJobStartProcess(Argument::any(), Argument::any(), Argument::any(), Argument::any())
-            ->willReturn($startProcess->reveal());
-
-        $this->processFactory->getTearDownProcess(Argument::any(), Argument::any())
-            ->willReturn($tearDownProcess->reveal());
-    }
+interface Listener
+{
+    public function listenToAll();
 }

--- a/tests/Models/RunningCommandTest.php
+++ b/tests/Models/RunningCommandTest.php
@@ -22,7 +22,7 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Process;
-use Trivago\Rumi\Process\RunningProcessesFactory;
+use Trivago\Rumi\Process\RunningProcessFactoryInterface;
 
 /**
  * @covers \Trivago\Rumi\Models\RunningCommand
@@ -40,7 +40,7 @@ class RunningCommandTest extends \PHPUnit_Framework_TestCase
     private $jobConfig;
 
     /**
-     * @var RunningProcessesFactory
+     * @var RunningProcessFactoryInterface
      */
     private $runningProcessFactory;
 
@@ -53,7 +53,7 @@ class RunningCommandTest extends \PHPUnit_Framework_TestCase
     {
         $this->eventDispather = $this->prophesize(EventDispatcherInterface::class);
         $this->jobConfig = $this->prophesize(JobConfig::class);
-        $this->runningProcessFactory = $this->prophesize(RunningProcessesFactory::class);
+        $this->runningProcessFactory = $this->prophesize(RunningProcessFactoryInterface::class);
         $this->SUT = new RunningCommand(
             $this->jobConfig->reveal(),
             'path',

--- a/tests/Process/RunningProcessesFactoryTest.php
+++ b/tests/Process/RunningProcessesFactoryTest.php
@@ -20,6 +20,7 @@ namespace Trivago\Rumi\Process;
 
 /**
  * @covers \Trivago\Rumi\Process\RunningProcessesFactory
+ * @SuppressWarnings(PHPMD.StaticAccess)
  */
 class RunningProcessesFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,15 +31,14 @@ class RunningProcessesFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        RunningProcessesFactory::enableTearDown();
         $this->SUT = new RunningProcessesFactory();
     }
 
     public function testGetJobStartProcess()
     {
         $timeout = 1200;
-        $process = $this->SUT->getJobStartProcess(
-            'a', 'b', 'c', $timeout
-        );
+        $process = $this->SUT->getJobStartProcess('a', 'b', 'c', $timeout);
         $this->assertEquals('docker-compose -f a run --name b c 2>&1', $process->getCommandLine());
         $this->assertEquals($timeout, $process->getTimeout());
         $this->assertEquals($timeout, $process->getIdleTimeout());
@@ -46,11 +46,16 @@ class RunningProcessesFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTearDownProcess()
     {
-        $process = $this->SUT->getTearDownProcess(
-            'a', 'b'
-        );
+        $process = $this->SUT->getTearDownProcess('a', 'b');
         $this->assertEquals('docker rm -f b;
             docker-compose -f a rm -v --force;
             docker rm -f $(docker-compose -f a ps -q)', $process->getCommandLine());
+    }
+
+    public function testTearDownShouldBeDisabled()
+    {
+        RunningProcessesFactory::disableTearDown();
+        $process = $this->SUT->getTearDownProcess(__METHOD__, __NAMESPACE__);
+        $this->assertContains('skip', $process->getCommandLine());
     }
 }

--- a/tests/Process/RunningProcessesFactoryTest.php
+++ b/tests/Process/RunningProcessesFactoryTest.php
@@ -19,20 +19,19 @@
 namespace Trivago\Rumi\Process;
 
 /**
- * @covers \Trivago\Rumi\Process\RunningProcessesFactory
+ * @covers \Trivago\Rumi\Process\RunningProcessFactoryInterface
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
 class RunningProcessesFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var RunningProcessesFactory
+     * @var RunningProcessFactoryInterface
      */
     private $SUT;
 
     public function setUp()
     {
-        RunningProcessesFactory::enableTearDown();
-        $this->SUT = new RunningProcessesFactory();
+        $this->SUT = new RunningProcessFactory();
     }
 
     public function testGetJobStartProcess()
@@ -50,12 +49,5 @@ class RunningProcessesFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('docker rm -f b;
             docker-compose -f a rm -v --force;
             docker rm -f $(docker-compose -f a ps -q)', $process->getCommandLine());
-    }
-
-    public function testTearDownShouldBeDisabled()
-    {
-        RunningProcessesFactory::disableTearDown();
-        $process = $this->SUT->getTearDownProcess(__METHOD__, __NAMESPACE__);
-        $this->assertContains('skip', $process->getCommandLine());
     }
 }


### PR DESCRIPTION
In some cases you want to keep the docker container still running. For
instance for debugging issues. In this case a option --no-teardown is
introduced which skips the tear down process for removing the launched
docker container. The implementation is simple and will be probably
improved.